### PR TITLE
Support for CRA 5

### DIFF
--- a/packages/craco/lib/features/jest/create-jest-babel-transform.js
+++ b/packages/craco/lib/features/jest/create-jest-babel-transform.js
@@ -1,4 +1,4 @@
-const babelJest = require("babel-jest");
+const babelJest = require("babel-jest").default;
 
 const { isArray } = require("../../utils");
 /**

--- a/packages/craco/lib/features/jest/jest-babel-transform.js
+++ b/packages/craco/lib/features/jest/jest-babel-transform.js
@@ -1,3 +1,4 @@
+const { loadCracoConfigAsync } = require("../../config");
 const { createJestBabelTransform } = require("./create-jest-babel-transform");
 
 let jestBabelTransform;
@@ -7,9 +8,11 @@ let jestBabelTransform;
 // uses that to process files.
 module.exports = {
     ...createJestBabelTransform(),
-    process(src, filename, config, transformOptions) {
+    async processAsync(src, filename, config, transformOptions) {
         if (!jestBabelTransform) {
-            jestBabelTransform = createJestBabelTransform(config.globals._cracoConfig);
+            const context = { env: process.env.NODE_ENV };
+            const cracoConfig = await loadCracoConfigAsync(context);
+            jestBabelTransform = createJestBabelTransform(cracoConfig);
         }
 
         return jestBabelTransform.process(src, filename, config, transformOptions);

--- a/packages/craco/lib/features/jest/merge-jest-config.js
+++ b/packages/craco/lib/features/jest/merge-jest-config.js
@@ -7,12 +7,7 @@ const { projectRoot } = require("../../paths");
 
 const BABEL_TRANSFORM_ENTRY_KEY = "^.+\\.(js|jsx|mjs|cjs|ts|tsx)$";
 
-function overrideBabelTransform(jestConfig, cracoConfig, transformKey) {
-    // The cracoConfig needs to be available within the jest-babel-transform in order to honor its settings.
-    // This approach is based on https://github.com/facebook/jest/issues/1468#issuecomment-384825178
-    jestConfig.globals = jestConfig.globals || {};
-    jestConfig.globals._cracoConfig = cracoConfig;
-
+function overrideBabelTransform(jestConfig, transformKey) {
     jestConfig.transform[transformKey] = require.resolve("./jest-babel-transform");
 
     log("Overrided Jest Babel transformer.");
@@ -27,7 +22,7 @@ function configureBabel(jestConfig, cracoConfig) {
 
             if (isArray(presets) || isArray(plugins)) {
                 if (jestConfig.transform[BABEL_TRANSFORM_ENTRY_KEY]) {
-                    overrideBabelTransform(jestConfig, cracoConfig, BABEL_TRANSFORM_ENTRY_KEY);
+                    overrideBabelTransform(jestConfig, BABEL_TRANSFORM_ENTRY_KEY);
                 } else {
                     throw new Error(`craco: Cannot find Jest transform entry for Babel ${BABEL_TRANSFORM_ENTRY_KEY}.`);
                 }


### PR DESCRIPTION
Fixes #313

Doesn't update the peer dependency, but this does allow craco to work with react-scripts 5. I have not tested every feature so it's possible there's some config-munging that expects a now-changed format.

Right now this isn't backwards compatible with react-scripts 4, as I needed to use Jest 27's async transformations (it seems globals are now getting cleared). I can look into adding conditional support based on the Jest version, but putting this up now in case others want to play with it.