### PR TITLE
allow build script to use existing NODE_ENV value

### DIFF
--- a/packages/craco/src/scripts/build.ts
+++ b/packages/craco/src/scripts/build.ts
@@ -1,6 +1,6 @@
 import type { BaseContext } from '@craco/types';
 
-process.env.NODE_ENV = 'production';
+process.env.NODE_ENV = process.env.NODE_ENV || 'production';
 
 import { findArgsFromCli } from '../lib/args';
 
@@ -9,7 +9,7 @@ findArgsFromCli();
 
 import { loadCracoConfigAsync } from '../lib/config';
 import { build, getCraPaths } from '../lib/cra';
-import { overrideWebpackProd } from '../lib/features/webpack/override';
+import { overrideWebpackProd, overrideWebpackDev } from '../lib/features/webpack/override';
 import { log } from '../lib/logger';
 import { validateCraVersion } from '../lib/validate-cra-version';
 
@@ -25,6 +25,6 @@ loadCracoConfigAsync(context).then((cracoConfig) => {
 
   context.paths = getCraPaths(cracoConfig);
 
-  overrideWebpackProd(cracoConfig, context);
+  process.env.NODE_ENV === 'production' ? overrideWebpackProd(cracoConfig, context) : overrideWebpackDev(cracoConfig, context);
   build(cracoConfig);
 });


### PR DESCRIPTION
in some special projects, we have both "development" builds, and "production" builds.  With this PR, the build script will use the webpack production config only if the NODE_ENV is set to "production" (which is the default, if no value has been assigned). In any other cases, it will use the webpack development config. 