### PR TITLE
feat: Override CRA paths

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,5 @@
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "useNx": true,
   "useWorkspaces": true,
-  "version": "7.0.0"
+  "version": "7.0.1"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2067,14 +2067,6 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
-    "node_modules/@craco/craco": {
-      "resolved": "packages/craco",
-      "link": true
-    },
-    "node_modules/@craco/types": {
-      "resolved": "packages/craco-types",
-      "link": true
-    },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
@@ -6201,6 +6193,14 @@
         "@webassemblyjs/ast": "1.11.1",
         "@xtuc/long": "4.2.2"
       }
+    },
+    "node_modules/@webolucio/craco": {
+      "resolved": "packages/craco",
+      "link": true
+    },
+    "node_modules/@webolucio/craco-types": {
+      "resolved": "packages/craco-types",
+      "link": true
     },
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",
@@ -23150,8 +23150,8 @@
       }
     },
     "packages/craco": {
-      "name": "@craco/craco",
-      "version": "7.0.0",
+      "name": "@webolucio/craco",
+      "version": "7.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "autoprefixer": "^10.4.12",
@@ -23167,13 +23167,13 @@
       },
       "devDependencies": {
         "@babel/types": "^7.19.3",
-        "@craco/types": "*",
         "@jest/types": "^29.1.2",
         "@types/cross-spawn": "^6.0.2",
         "@types/eslint": "^8.4.6",
         "@types/jest": "^29.1.1",
         "@types/lodash": "^4.14.186",
         "@types/semver": "^7.3.12",
+        "@webolucio/craco-types": "^7.0.1",
         "eslint-webpack-plugin": "^3.2.0",
         "jest": "^29.1.2",
         "react-scripts": "5.*",
@@ -23189,8 +23189,8 @@
       }
     },
     "packages/craco-types": {
-      "name": "@craco/types",
-      "version": "7.0.0",
+      "name": "@webolucio/craco-types",
+      "version": "7.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/types": "^7.19.3",
@@ -25647,806 +25647,6 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
-    },
-    "@craco/craco": {
-      "version": "file:packages/craco",
-      "requires": {
-        "@babel/types": "^7.19.3",
-        "@craco/types": "*",
-        "@jest/types": "^29.1.2",
-        "@types/cross-spawn": "^6.0.2",
-        "@types/eslint": "^8.4.6",
-        "@types/jest": "^29.1.1",
-        "@types/lodash": "^4.14.186",
-        "@types/semver": "^7.3.12",
-        "autoprefixer": "^10.4.12",
-        "cosmiconfig": "^7.0.1",
-        "cosmiconfig-typescript-loader": "^1.0.0",
-        "cross-spawn": "^7.0.3",
-        "eslint-webpack-plugin": "^3.2.0",
-        "jest": "^29.1.2",
-        "lodash": "^4.17.21",
-        "react-scripts": "5.*",
-        "semver": "^7.3.7",
-        "ts-jest": "^29.0.3",
-        "typescript": "^4.8.4",
-        "webpack": "^5.74.0",
-        "webpack-merge": "^5.8.0"
-      },
-      "dependencies": {
-        "@jest/console": {
-          "version": "29.1.2",
-          "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.1.2.tgz",
-          "integrity": "sha512-ujEBCcYs82BTmRxqfHMQggSlkUZP63AE5YEaTPj7eFyJOzukkTorstOUC7L6nE3w5SYadGVAnTsQ/ZjTGL0qYQ==",
-          "dev": true,
-          "requires": {
-            "@jest/types": "^29.1.2",
-            "@types/node": "*",
-            "chalk": "^4.0.0",
-            "jest-message-util": "^29.1.2",
-            "jest-util": "^29.1.2",
-            "slash": "^3.0.0"
-          }
-        },
-        "@jest/core": {
-          "version": "29.1.2",
-          "resolved": "https://registry.npmjs.org/@jest/core/-/core-29.1.2.tgz",
-          "integrity": "sha512-sCO2Va1gikvQU2ynDN8V4+6wB7iVrD2CvT0zaRst4rglf56yLly0NQ9nuRRAWFeimRf+tCdFsb1Vk1N9LrrMPA==",
-          "dev": true,
-          "requires": {
-            "@jest/console": "^29.1.2",
-            "@jest/reporters": "^29.1.2",
-            "@jest/test-result": "^29.1.2",
-            "@jest/transform": "^29.1.2",
-            "@jest/types": "^29.1.2",
-            "@types/node": "*",
-            "ansi-escapes": "^4.2.1",
-            "chalk": "^4.0.0",
-            "ci-info": "^3.2.0",
-            "exit": "^0.1.2",
-            "graceful-fs": "^4.2.9",
-            "jest-changed-files": "^29.0.0",
-            "jest-config": "^29.1.2",
-            "jest-haste-map": "^29.1.2",
-            "jest-message-util": "^29.1.2",
-            "jest-regex-util": "^29.0.0",
-            "jest-resolve": "^29.1.2",
-            "jest-resolve-dependencies": "^29.1.2",
-            "jest-runner": "^29.1.2",
-            "jest-runtime": "^29.1.2",
-            "jest-snapshot": "^29.1.2",
-            "jest-util": "^29.1.2",
-            "jest-validate": "^29.1.2",
-            "jest-watcher": "^29.1.2",
-            "micromatch": "^4.0.4",
-            "pretty-format": "^29.1.2",
-            "slash": "^3.0.0",
-            "strip-ansi": "^6.0.0"
-          }
-        },
-        "@jest/environment": {
-          "version": "29.1.2",
-          "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.1.2.tgz",
-          "integrity": "sha512-rG7xZ2UeOfvOVzoLIJ0ZmvPl4tBEQ2n73CZJSlzUjPw4or1oSWC0s0Rk0ZX+pIBJ04aVr6hLWFn1DFtrnf8MhQ==",
-          "dev": true,
-          "requires": {
-            "@jest/fake-timers": "^29.1.2",
-            "@jest/types": "^29.1.2",
-            "@types/node": "*",
-            "jest-mock": "^29.1.2"
-          }
-        },
-        "@jest/expect": {
-          "version": "29.1.2",
-          "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.1.2.tgz",
-          "integrity": "sha512-FXw/UmaZsyfRyvZw3M6POgSNqwmuOXJuzdNiMWW9LCYo0GRoRDhg+R5iq5higmRTHQY7hx32+j7WHwinRmoILQ==",
-          "dev": true,
-          "requires": {
-            "expect": "^29.1.2",
-            "jest-snapshot": "^29.1.2"
-          }
-        },
-        "@jest/expect-utils": {
-          "version": "29.1.2",
-          "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.1.2.tgz",
-          "integrity": "sha512-4a48bhKfGj/KAH39u0ppzNTABXQ8QPccWAFUFobWBaEMSMp+sB31Z2fK/l47c4a/Mu1po2ffmfAIPxXbVTXdtg==",
-          "dev": true,
-          "requires": {
-            "jest-get-type": "^29.0.0"
-          }
-        },
-        "@jest/fake-timers": {
-          "version": "29.1.2",
-          "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.1.2.tgz",
-          "integrity": "sha512-GppaEqS+QQYegedxVMpCe2xCXxxeYwQ7RsNx55zc8f+1q1qevkZGKequfTASI7ejmg9WwI+SJCrHe9X11bLL9Q==",
-          "dev": true,
-          "requires": {
-            "@jest/types": "^29.1.2",
-            "@sinonjs/fake-timers": "^9.1.2",
-            "@types/node": "*",
-            "jest-message-util": "^29.1.2",
-            "jest-mock": "^29.1.2",
-            "jest-util": "^29.1.2"
-          }
-        },
-        "@jest/globals": {
-          "version": "29.1.2",
-          "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.1.2.tgz",
-          "integrity": "sha512-uMgfERpJYoQmykAd0ffyMq8wignN4SvLUG6orJQRe9WAlTRc9cdpCaE/29qurXixYJVZWUqIBXhSk8v5xN1V9g==",
-          "dev": true,
-          "requires": {
-            "@jest/environment": "^29.1.2",
-            "@jest/expect": "^29.1.2",
-            "@jest/types": "^29.1.2",
-            "jest-mock": "^29.1.2"
-          }
-        },
-        "@jest/reporters": {
-          "version": "29.1.2",
-          "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.1.2.tgz",
-          "integrity": "sha512-X4fiwwyxy9mnfpxL0g9DD0KcTmEIqP0jUdnc2cfa9riHy+I6Gwwp5vOZiwyg0vZxfSDxrOlK9S4+340W4d+DAA==",
-          "dev": true,
-          "requires": {
-            "@bcoe/v8-coverage": "^0.2.3",
-            "@jest/console": "^29.1.2",
-            "@jest/test-result": "^29.1.2",
-            "@jest/transform": "^29.1.2",
-            "@jest/types": "^29.1.2",
-            "@jridgewell/trace-mapping": "^0.3.15",
-            "@types/node": "*",
-            "chalk": "^4.0.0",
-            "collect-v8-coverage": "^1.0.0",
-            "exit": "^0.1.2",
-            "glob": "^7.1.3",
-            "graceful-fs": "^4.2.9",
-            "istanbul-lib-coverage": "^3.0.0",
-            "istanbul-lib-instrument": "^5.1.0",
-            "istanbul-lib-report": "^3.0.0",
-            "istanbul-lib-source-maps": "^4.0.0",
-            "istanbul-reports": "^3.1.3",
-            "jest-message-util": "^29.1.2",
-            "jest-util": "^29.1.2",
-            "jest-worker": "^29.1.2",
-            "slash": "^3.0.0",
-            "string-length": "^4.0.1",
-            "strip-ansi": "^6.0.0",
-            "terminal-link": "^2.0.0",
-            "v8-to-istanbul": "^9.0.1"
-          }
-        },
-        "@jest/schemas": {
-          "version": "29.0.0",
-          "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.0.0.tgz",
-          "integrity": "sha512-3Ab5HgYIIAnS0HjqJHQYZS+zXc4tUmTmBH3z83ajI6afXp8X3ZtdLX+nXx+I7LNkJD7uN9LAVhgnjDgZa2z0kA==",
-          "dev": true,
-          "requires": {
-            "@sinclair/typebox": "^0.24.1"
-          }
-        },
-        "@jest/source-map": {
-          "version": "29.0.0",
-          "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-29.0.0.tgz",
-          "integrity": "sha512-nOr+0EM8GiHf34mq2GcJyz/gYFyLQ2INDhAylrZJ9mMWoW21mLBfZa0BUVPPMxVYrLjeiRe2Z7kWXOGnS0TFhQ==",
-          "dev": true,
-          "requires": {
-            "@jridgewell/trace-mapping": "^0.3.15",
-            "callsites": "^3.0.0",
-            "graceful-fs": "^4.2.9"
-          }
-        },
-        "@jest/test-result": {
-          "version": "29.1.2",
-          "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.1.2.tgz",
-          "integrity": "sha512-jjYYjjumCJjH9hHCoMhA8PCl1OxNeGgAoZ7yuGYILRJX9NjgzTN0pCT5qAoYR4jfOP8htIByvAlz9vfNSSBoVg==",
-          "dev": true,
-          "requires": {
-            "@jest/console": "^29.1.2",
-            "@jest/types": "^29.1.2",
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "collect-v8-coverage": "^1.0.0"
-          }
-        },
-        "@jest/test-sequencer": {
-          "version": "29.1.2",
-          "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.1.2.tgz",
-          "integrity": "sha512-fU6dsUqqm8sA+cd85BmeF7Gu9DsXVWFdGn9taxM6xN1cKdcP/ivSgXh5QucFRFz1oZxKv3/9DYYbq0ULly3P/Q==",
-          "dev": true,
-          "requires": {
-            "@jest/test-result": "^29.1.2",
-            "graceful-fs": "^4.2.9",
-            "jest-haste-map": "^29.1.2",
-            "slash": "^3.0.0"
-          }
-        },
-        "@jest/transform": {
-          "version": "29.1.2",
-          "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.1.2.tgz",
-          "integrity": "sha512-2uaUuVHTitmkx1tHF+eBjb4p7UuzBG7SXIaA/hNIkaMP6K+gXYGxP38ZcrofzqN0HeZ7A90oqsOa97WU7WZkSw==",
-          "dev": true,
-          "requires": {
-            "@babel/core": "^7.11.6",
-            "@jest/types": "^29.1.2",
-            "@jridgewell/trace-mapping": "^0.3.15",
-            "babel-plugin-istanbul": "^6.1.1",
-            "chalk": "^4.0.0",
-            "convert-source-map": "^1.4.0",
-            "fast-json-stable-stringify": "^2.1.0",
-            "graceful-fs": "^4.2.9",
-            "jest-haste-map": "^29.1.2",
-            "jest-regex-util": "^29.0.0",
-            "jest-util": "^29.1.2",
-            "micromatch": "^4.0.4",
-            "pirates": "^4.0.4",
-            "slash": "^3.0.0",
-            "write-file-atomic": "^4.0.1"
-          }
-        },
-        "@jest/types": {
-          "version": "29.1.2",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.1.2.tgz",
-          "integrity": "sha512-DcXGtoTykQB5jiwCmVr8H4vdg2OJhQex3qPkG+ISyDO7xQXbt/4R6dowcRyPemRnkH7JoHvZuxPBdlq+9JxFCg==",
-          "dev": true,
-          "requires": {
-            "@jest/schemas": "^29.0.0",
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^3.0.0",
-            "@types/node": "*",
-            "@types/yargs": "^17.0.8",
-            "chalk": "^4.0.0"
-          }
-        },
-        "ansi-styles": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-          "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-          "dev": true
-        },
-        "babel-jest": {
-          "version": "29.1.2",
-          "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.1.2.tgz",
-          "integrity": "sha512-IuG+F3HTHryJb7gacC7SQ59A9kO56BctUsT67uJHp1mMCHUOMXpDwOHWGifWqdWVknN2WNkCVQELPjXx0aLJ9Q==",
-          "dev": true,
-          "requires": {
-            "@jest/transform": "^29.1.2",
-            "@types/babel__core": "^7.1.14",
-            "babel-plugin-istanbul": "^6.1.1",
-            "babel-preset-jest": "^29.0.2",
-            "chalk": "^4.0.0",
-            "graceful-fs": "^4.2.9",
-            "slash": "^3.0.0"
-          }
-        },
-        "babel-plugin-jest-hoist": {
-          "version": "29.0.2",
-          "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.0.2.tgz",
-          "integrity": "sha512-eBr2ynAEFjcebVvu8Ktx580BD1QKCrBG1XwEUTXJe285p9HA/4hOhfWCFRQhTKSyBV0VzjhG7H91Eifz9s29hg==",
-          "dev": true,
-          "requires": {
-            "@babel/template": "^7.3.3",
-            "@babel/types": "^7.3.3",
-            "@types/babel__core": "^7.1.14",
-            "@types/babel__traverse": "^7.0.6"
-          }
-        },
-        "babel-preset-jest": {
-          "version": "29.0.2",
-          "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-29.0.2.tgz",
-          "integrity": "sha512-BeVXp7rH5TK96ofyEnHjznjLMQ2nAeDJ+QzxKnHAAMs0RgrQsCywjAN8m4mOm5Di0pxU//3AoEeJJrerMH5UeA==",
-          "dev": true,
-          "requires": {
-            "babel-plugin-jest-hoist": "^29.0.2",
-            "babel-preset-current-node-syntax": "^1.0.0"
-          }
-        },
-        "camelcase": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
-          "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
-          "dev": true
-        },
-        "cosmiconfig-typescript-loader": {
-          "version": "1.0.9",
-          "resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-1.0.9.tgz",
-          "integrity": "sha512-tRuMRhxN4m1Y8hP9SNYfz7jRwt8lZdWxdjg/ohg5esKmsndJIn4yT96oJVcf5x0eA11taXl+sIp+ielu529k6g==",
-          "requires": {
-            "cosmiconfig": "^7",
-            "ts-node": "^10.7.0"
-          }
-        },
-        "diff-sequences": {
-          "version": "29.0.0",
-          "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.0.0.tgz",
-          "integrity": "sha512-7Qe/zd1wxSDL4D/X/FPjOMB+ZMDt71W94KYaq05I2l0oQqgXgs7s4ftYYmV38gBSrPz2vcygxfs1xn0FT+rKNA==",
-          "dev": true
-        },
-        "expect": {
-          "version": "29.1.2",
-          "resolved": "https://registry.npmjs.org/expect/-/expect-29.1.2.tgz",
-          "integrity": "sha512-AuAGn1uxva5YBbBlXb+2JPxJRuemZsmlGcapPXWNSBNsQtAULfjioREGBWuI0EOvYUKjDnrCy8PW5Zlr1md5mw==",
-          "dev": true,
-          "requires": {
-            "@jest/expect-utils": "^29.1.2",
-            "jest-get-type": "^29.0.0",
-            "jest-matcher-utils": "^29.1.2",
-            "jest-message-util": "^29.1.2",
-            "jest-util": "^29.1.2"
-          }
-        },
-        "jest": {
-          "version": "29.1.2",
-          "resolved": "https://registry.npmjs.org/jest/-/jest-29.1.2.tgz",
-          "integrity": "sha512-5wEIPpCezgORnqf+rCaYD1SK+mNN7NsstWzIsuvsnrhR/hSxXWd82oI7DkrbJ+XTD28/eG8SmxdGvukrGGK6Tw==",
-          "dev": true,
-          "requires": {
-            "@jest/core": "^29.1.2",
-            "@jest/types": "^29.1.2",
-            "import-local": "^3.0.2",
-            "jest-cli": "^29.1.2"
-          }
-        },
-        "jest-changed-files": {
-          "version": "29.0.0",
-          "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-29.0.0.tgz",
-          "integrity": "sha512-28/iDMDrUpGoCitTURuDqUzWQoWmOmOKOFST1mi2lwh62X4BFf6khgH3uSuo1e49X/UDjuApAj3w0wLOex4VPQ==",
-          "dev": true,
-          "requires": {
-            "execa": "^5.0.0",
-            "p-limit": "^3.1.0"
-          }
-        },
-        "jest-circus": {
-          "version": "29.1.2",
-          "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.1.2.tgz",
-          "integrity": "sha512-ajQOdxY6mT9GtnfJRZBRYS7toNIJayiiyjDyoZcnvPRUPwJ58JX0ci0PKAKUo2C1RyzlHw0jabjLGKksO42JGA==",
-          "dev": true,
-          "requires": {
-            "@jest/environment": "^29.1.2",
-            "@jest/expect": "^29.1.2",
-            "@jest/test-result": "^29.1.2",
-            "@jest/types": "^29.1.2",
-            "@types/node": "*",
-            "chalk": "^4.0.0",
-            "co": "^4.6.0",
-            "dedent": "^0.7.0",
-            "is-generator-fn": "^2.0.0",
-            "jest-each": "^29.1.2",
-            "jest-matcher-utils": "^29.1.2",
-            "jest-message-util": "^29.1.2",
-            "jest-runtime": "^29.1.2",
-            "jest-snapshot": "^29.1.2",
-            "jest-util": "^29.1.2",
-            "p-limit": "^3.1.0",
-            "pretty-format": "^29.1.2",
-            "slash": "^3.0.0",
-            "stack-utils": "^2.0.3"
-          }
-        },
-        "jest-cli": {
-          "version": "29.1.2",
-          "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-29.1.2.tgz",
-          "integrity": "sha512-vsvBfQ7oS2o4MJdAH+4u9z76Vw5Q8WBQF5MchDbkylNknZdrPTX1Ix7YRJyTlOWqRaS7ue/cEAn+E4V1MWyMzw==",
-          "dev": true,
-          "requires": {
-            "@jest/core": "^29.1.2",
-            "@jest/test-result": "^29.1.2",
-            "@jest/types": "^29.1.2",
-            "chalk": "^4.0.0",
-            "exit": "^0.1.2",
-            "graceful-fs": "^4.2.9",
-            "import-local": "^3.0.2",
-            "jest-config": "^29.1.2",
-            "jest-util": "^29.1.2",
-            "jest-validate": "^29.1.2",
-            "prompts": "^2.0.1",
-            "yargs": "^17.3.1"
-          }
-        },
-        "jest-config": {
-          "version": "29.1.2",
-          "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.1.2.tgz",
-          "integrity": "sha512-EC3Zi86HJUOz+2YWQcJYQXlf0zuBhJoeyxLM6vb6qJsVmpP7KcCP1JnyF0iaqTaXdBP8Rlwsvs7hnKWQWWLwwA==",
-          "dev": true,
-          "requires": {
-            "@babel/core": "^7.11.6",
-            "@jest/test-sequencer": "^29.1.2",
-            "@jest/types": "^29.1.2",
-            "babel-jest": "^29.1.2",
-            "chalk": "^4.0.0",
-            "ci-info": "^3.2.0",
-            "deepmerge": "^4.2.2",
-            "glob": "^7.1.3",
-            "graceful-fs": "^4.2.9",
-            "jest-circus": "^29.1.2",
-            "jest-environment-node": "^29.1.2",
-            "jest-get-type": "^29.0.0",
-            "jest-regex-util": "^29.0.0",
-            "jest-resolve": "^29.1.2",
-            "jest-runner": "^29.1.2",
-            "jest-util": "^29.1.2",
-            "jest-validate": "^29.1.2",
-            "micromatch": "^4.0.4",
-            "parse-json": "^5.2.0",
-            "pretty-format": "^29.1.2",
-            "slash": "^3.0.0",
-            "strip-json-comments": "^3.1.1"
-          }
-        },
-        "jest-diff": {
-          "version": "29.1.2",
-          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.1.2.tgz",
-          "integrity": "sha512-4GQts0aUopVvecIT4IwD/7xsBaMhKTYoM4/njE/aVw9wpw+pIUVp8Vab/KnSzSilr84GnLBkaP3JLDnQYCKqVQ==",
-          "dev": true,
-          "requires": {
-            "chalk": "^4.0.0",
-            "diff-sequences": "^29.0.0",
-            "jest-get-type": "^29.0.0",
-            "pretty-format": "^29.1.2"
-          }
-        },
-        "jest-docblock": {
-          "version": "29.0.0",
-          "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.0.0.tgz",
-          "integrity": "sha512-s5Kpra/kLzbqu9dEjov30kj1n4tfu3e7Pl8v+f8jOkeWNqM6Ds8jRaJfZow3ducoQUrf2Z4rs2N5S3zXnb83gw==",
-          "dev": true,
-          "requires": {
-            "detect-newline": "^3.0.0"
-          }
-        },
-        "jest-each": {
-          "version": "29.1.2",
-          "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-29.1.2.tgz",
-          "integrity": "sha512-AmTQp9b2etNeEwMyr4jc0Ql/LIX/dhbgP21gHAizya2X6rUspHn2gysMXaj6iwWuOJ2sYRgP8c1P4cXswgvS1A==",
-          "dev": true,
-          "requires": {
-            "@jest/types": "^29.1.2",
-            "chalk": "^4.0.0",
-            "jest-get-type": "^29.0.0",
-            "jest-util": "^29.1.2",
-            "pretty-format": "^29.1.2"
-          }
-        },
-        "jest-environment-node": {
-          "version": "29.1.2",
-          "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.1.2.tgz",
-          "integrity": "sha512-C59yVbdpY8682u6k/lh8SUMDJPbOyCHOTgLVVi1USWFxtNV+J8fyIwzkg+RJIVI30EKhKiAGNxYaFr3z6eyNhQ==",
-          "dev": true,
-          "requires": {
-            "@jest/environment": "^29.1.2",
-            "@jest/fake-timers": "^29.1.2",
-            "@jest/types": "^29.1.2",
-            "@types/node": "*",
-            "jest-mock": "^29.1.2",
-            "jest-util": "^29.1.2"
-          }
-        },
-        "jest-get-type": {
-          "version": "29.0.0",
-          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.0.0.tgz",
-          "integrity": "sha512-83X19z/HuLKYXYHskZlBAShO7UfLFXu/vWajw9ZNJASN32li8yHMaVGAQqxFW1RCFOkB7cubaL6FaJVQqqJLSw==",
-          "dev": true
-        },
-        "jest-haste-map": {
-          "version": "29.1.2",
-          "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.1.2.tgz",
-          "integrity": "sha512-xSjbY8/BF11Jh3hGSPfYTa/qBFrm3TPM7WU8pU93m2gqzORVLkHFWvuZmFsTEBPRKndfewXhMOuzJNHyJIZGsw==",
-          "dev": true,
-          "requires": {
-            "@jest/types": "^29.1.2",
-            "@types/graceful-fs": "^4.1.3",
-            "@types/node": "*",
-            "anymatch": "^3.0.3",
-            "fb-watchman": "^2.0.0",
-            "fsevents": "^2.3.2",
-            "graceful-fs": "^4.2.9",
-            "jest-regex-util": "^29.0.0",
-            "jest-util": "^29.1.2",
-            "jest-worker": "^29.1.2",
-            "micromatch": "^4.0.4",
-            "walker": "^1.0.8"
-          }
-        },
-        "jest-leak-detector": {
-          "version": "29.1.2",
-          "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.1.2.tgz",
-          "integrity": "sha512-TG5gAZJpgmZtjb6oWxBLf2N6CfQ73iwCe6cofu/Uqv9iiAm6g502CAnGtxQaTfpHECBdVEMRBhomSXeLnoKjiQ==",
-          "dev": true,
-          "requires": {
-            "jest-get-type": "^29.0.0",
-            "pretty-format": "^29.1.2"
-          }
-        },
-        "jest-matcher-utils": {
-          "version": "29.1.2",
-          "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.1.2.tgz",
-          "integrity": "sha512-MV5XrD3qYSW2zZSHRRceFzqJ39B2z11Qv0KPyZYxnzDHFeYZGJlgGi0SW+IXSJfOewgJp/Km/7lpcFT+cgZypw==",
-          "dev": true,
-          "requires": {
-            "chalk": "^4.0.0",
-            "jest-diff": "^29.1.2",
-            "jest-get-type": "^29.0.0",
-            "pretty-format": "^29.1.2"
-          }
-        },
-        "jest-message-util": {
-          "version": "29.1.2",
-          "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.1.2.tgz",
-          "integrity": "sha512-9oJ2Os+Qh6IlxLpmvshVbGUiSkZVc2FK+uGOm6tghafnB2RyjKAxMZhtxThRMxfX1J1SOMhTn9oK3/MutRWQJQ==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "^7.12.13",
-            "@jest/types": "^29.1.2",
-            "@types/stack-utils": "^2.0.0",
-            "chalk": "^4.0.0",
-            "graceful-fs": "^4.2.9",
-            "micromatch": "^4.0.4",
-            "pretty-format": "^29.1.2",
-            "slash": "^3.0.0",
-            "stack-utils": "^2.0.3"
-          }
-        },
-        "jest-mock": {
-          "version": "29.1.2",
-          "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.1.2.tgz",
-          "integrity": "sha512-PFDAdjjWbjPUtQPkQufvniXIS3N9Tv7tbibePEjIIprzjgo0qQlyUiVMrT4vL8FaSJo1QXifQUOuPH3HQC/aMA==",
-          "dev": true,
-          "requires": {
-            "@jest/types": "^29.1.2",
-            "@types/node": "*",
-            "jest-util": "^29.1.2"
-          }
-        },
-        "jest-regex-util": {
-          "version": "29.0.0",
-          "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.0.0.tgz",
-          "integrity": "sha512-BV7VW7Sy0fInHWN93MMPtlClweYv2qrSCwfeFWmpribGZtQPWNvRSq9XOVgOEjU1iBGRKXUZil0o2AH7Iy9Lug==",
-          "dev": true
-        },
-        "jest-resolve": {
-          "version": "29.1.2",
-          "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.1.2.tgz",
-          "integrity": "sha512-7fcOr+k7UYSVRJYhSmJHIid3AnDBcLQX3VmT9OSbPWsWz1MfT7bcoerMhADKGvKCoMpOHUQaDHtQoNp/P9JMGg==",
-          "dev": true,
-          "requires": {
-            "chalk": "^4.0.0",
-            "graceful-fs": "^4.2.9",
-            "jest-haste-map": "^29.1.2",
-            "jest-pnp-resolver": "^1.2.2",
-            "jest-util": "^29.1.2",
-            "jest-validate": "^29.1.2",
-            "resolve": "^1.20.0",
-            "resolve.exports": "^1.1.0",
-            "slash": "^3.0.0"
-          }
-        },
-        "jest-resolve-dependencies": {
-          "version": "29.1.2",
-          "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-29.1.2.tgz",
-          "integrity": "sha512-44yYi+yHqNmH3OoWZvPgmeeiwKxhKV/0CfrzaKLSkZG9gT973PX8i+m8j6pDrTYhhHoiKfF3YUFg/6AeuHw4HQ==",
-          "dev": true,
-          "requires": {
-            "jest-regex-util": "^29.0.0",
-            "jest-snapshot": "^29.1.2"
-          }
-        },
-        "jest-runner": {
-          "version": "29.1.2",
-          "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.1.2.tgz",
-          "integrity": "sha512-yy3LEWw8KuBCmg7sCGDIqKwJlULBuNIQa2eFSVgVASWdXbMYZ9H/X0tnXt70XFoGf92W2sOQDOIFAA6f2BG04Q==",
-          "dev": true,
-          "requires": {
-            "@jest/console": "^29.1.2",
-            "@jest/environment": "^29.1.2",
-            "@jest/test-result": "^29.1.2",
-            "@jest/transform": "^29.1.2",
-            "@jest/types": "^29.1.2",
-            "@types/node": "*",
-            "chalk": "^4.0.0",
-            "emittery": "^0.10.2",
-            "graceful-fs": "^4.2.9",
-            "jest-docblock": "^29.0.0",
-            "jest-environment-node": "^29.1.2",
-            "jest-haste-map": "^29.1.2",
-            "jest-leak-detector": "^29.1.2",
-            "jest-message-util": "^29.1.2",
-            "jest-resolve": "^29.1.2",
-            "jest-runtime": "^29.1.2",
-            "jest-util": "^29.1.2",
-            "jest-watcher": "^29.1.2",
-            "jest-worker": "^29.1.2",
-            "p-limit": "^3.1.0",
-            "source-map-support": "0.5.13"
-          }
-        },
-        "jest-runtime": {
-          "version": "29.1.2",
-          "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.1.2.tgz",
-          "integrity": "sha512-jr8VJLIf+cYc+8hbrpt412n5jX3tiXmpPSYTGnwcvNemY+EOuLNiYnHJ3Kp25rkaAcTWOEI4ZdOIQcwYcXIAZw==",
-          "dev": true,
-          "requires": {
-            "@jest/environment": "^29.1.2",
-            "@jest/fake-timers": "^29.1.2",
-            "@jest/globals": "^29.1.2",
-            "@jest/source-map": "^29.0.0",
-            "@jest/test-result": "^29.1.2",
-            "@jest/transform": "^29.1.2",
-            "@jest/types": "^29.1.2",
-            "@types/node": "*",
-            "chalk": "^4.0.0",
-            "cjs-module-lexer": "^1.0.0",
-            "collect-v8-coverage": "^1.0.0",
-            "glob": "^7.1.3",
-            "graceful-fs": "^4.2.9",
-            "jest-haste-map": "^29.1.2",
-            "jest-message-util": "^29.1.2",
-            "jest-mock": "^29.1.2",
-            "jest-regex-util": "^29.0.0",
-            "jest-resolve": "^29.1.2",
-            "jest-snapshot": "^29.1.2",
-            "jest-util": "^29.1.2",
-            "slash": "^3.0.0",
-            "strip-bom": "^4.0.0"
-          }
-        },
-        "jest-snapshot": {
-          "version": "29.1.2",
-          "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.1.2.tgz",
-          "integrity": "sha512-rYFomGpVMdBlfwTYxkUp3sjD6usptvZcONFYNqVlaz4EpHPnDvlWjvmOQ9OCSNKqYZqLM2aS3wq01tWujLg7gg==",
-          "dev": true,
-          "requires": {
-            "@babel/core": "^7.11.6",
-            "@babel/generator": "^7.7.2",
-            "@babel/plugin-syntax-jsx": "^7.7.2",
-            "@babel/plugin-syntax-typescript": "^7.7.2",
-            "@babel/traverse": "^7.7.2",
-            "@babel/types": "^7.3.3",
-            "@jest/expect-utils": "^29.1.2",
-            "@jest/transform": "^29.1.2",
-            "@jest/types": "^29.1.2",
-            "@types/babel__traverse": "^7.0.6",
-            "@types/prettier": "^2.1.5",
-            "babel-preset-current-node-syntax": "^1.0.0",
-            "chalk": "^4.0.0",
-            "expect": "^29.1.2",
-            "graceful-fs": "^4.2.9",
-            "jest-diff": "^29.1.2",
-            "jest-get-type": "^29.0.0",
-            "jest-haste-map": "^29.1.2",
-            "jest-matcher-utils": "^29.1.2",
-            "jest-message-util": "^29.1.2",
-            "jest-util": "^29.1.2",
-            "natural-compare": "^1.4.0",
-            "pretty-format": "^29.1.2",
-            "semver": "^7.3.5"
-          }
-        },
-        "jest-util": {
-          "version": "29.1.2",
-          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.1.2.tgz",
-          "integrity": "sha512-vPCk9F353i0Ymx3WQq3+a4lZ07NXu9Ca8wya6o4Fe4/aO1e1awMMprZ3woPFpKwghEOW+UXgd15vVotuNN9ONQ==",
-          "dev": true,
-          "requires": {
-            "@jest/types": "^29.1.2",
-            "@types/node": "*",
-            "chalk": "^4.0.0",
-            "ci-info": "^3.2.0",
-            "graceful-fs": "^4.2.9",
-            "picomatch": "^2.2.3"
-          }
-        },
-        "jest-validate": {
-          "version": "29.1.2",
-          "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.1.2.tgz",
-          "integrity": "sha512-k71pOslNlV8fVyI+mEySy2pq9KdXdgZtm7NHrBX8LghJayc3wWZH0Yr0mtYNGaCU4F1OLPXRkwZR0dBm/ClshA==",
-          "dev": true,
-          "requires": {
-            "@jest/types": "^29.1.2",
-            "camelcase": "^6.2.0",
-            "chalk": "^4.0.0",
-            "jest-get-type": "^29.0.0",
-            "leven": "^3.1.0",
-            "pretty-format": "^29.1.2"
-          }
-        },
-        "jest-watcher": {
-          "version": "29.1.2",
-          "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.1.2.tgz",
-          "integrity": "sha512-6JUIUKVdAvcxC6bM8/dMgqY2N4lbT+jZVsxh0hCJRbwkIEnbr/aPjMQ28fNDI5lB51Klh00MWZZeVf27KBUj5w==",
-          "dev": true,
-          "requires": {
-            "@jest/test-result": "^29.1.2",
-            "@jest/types": "^29.1.2",
-            "@types/node": "*",
-            "ansi-escapes": "^4.2.1",
-            "chalk": "^4.0.0",
-            "emittery": "^0.10.2",
-            "jest-util": "^29.1.2",
-            "string-length": "^4.0.1"
-          }
-        },
-        "jest-worker": {
-          "version": "29.1.2",
-          "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.1.2.tgz",
-          "integrity": "sha512-AdTZJxKjTSPHbXT/AIOjQVmoFx0LHFcVabWu0sxI7PAy7rFf8c0upyvgBKgguVXdM4vY74JdwkyD4hSmpTW8jA==",
-          "dev": true,
-          "requires": {
-            "@types/node": "*",
-            "jest-util": "^29.1.2",
-            "merge-stream": "^2.0.0",
-            "supports-color": "^8.0.0"
-          }
-        },
-        "pretty-format": {
-          "version": "29.1.2",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.1.2.tgz",
-          "integrity": "sha512-CGJ6VVGXVRP2o2Dorl4mAwwvDWT25luIsYhkyVQW32E4nL+TgW939J7LlKT/npq5Cpq6j3s+sy+13yk7xYpBmg==",
-          "dev": true,
-          "requires": {
-            "@jest/schemas": "^29.0.0",
-            "ansi-styles": "^5.0.0",
-            "react-is": "^18.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "8.1.1",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-          "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        },
-        "ts-jest": {
-          "version": "29.0.3",
-          "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.0.3.tgz",
-          "integrity": "sha512-Ibygvmuyq1qp/z3yTh9QTwVVAbFdDy/+4BtIQR2sp6baF2SJU/8CKK/hhnGIDY2L90Az2jIqTwZPnN2p+BweiQ==",
-          "dev": true,
-          "requires": {
-            "bs-logger": "0.x",
-            "fast-json-stable-stringify": "2.x",
-            "jest-util": "^29.0.0",
-            "json5": "^2.2.1",
-            "lodash.memoize": "4.x",
-            "make-error": "1.x",
-            "semver": "7.x",
-            "yargs-parser": "^21.0.1"
-          }
-        }
-      }
-    },
-    "@craco/types": {
-      "version": "file:packages/craco-types",
-      "requires": {
-        "@babel/types": "^7.19.3",
-        "@jest/types": "^29.1.2",
-        "@types/eslint": "^8.4.6",
-        "autoprefixer": "^10.4.12",
-        "eslint-webpack-plugin": "^3.2.0",
-        "typescript": "^4.8.4",
-        "webpack": "^5.74.0"
-      },
-      "dependencies": {
-        "@jest/schemas": {
-          "version": "29.0.0",
-          "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.0.0.tgz",
-          "integrity": "sha512-3Ab5HgYIIAnS0HjqJHQYZS+zXc4tUmTmBH3z83ajI6afXp8X3ZtdLX+nXx+I7LNkJD7uN9LAVhgnjDgZa2z0kA==",
-          "requires": {
-            "@sinclair/typebox": "^0.24.1"
-          }
-        },
-        "@jest/types": {
-          "version": "29.1.2",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.1.2.tgz",
-          "integrity": "sha512-DcXGtoTykQB5jiwCmVr8H4vdg2OJhQex3qPkG+ISyDO7xQXbt/4R6dowcRyPemRnkH7JoHvZuxPBdlq+9JxFCg==",
-          "requires": {
-            "@jest/schemas": "^29.0.0",
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^3.0.0",
-            "@types/node": "*",
-            "@types/yargs": "^17.0.8",
-            "chalk": "^4.0.0"
-          }
-        }
-      }
     },
     "@cspotcode/source-map-support": {
       "version": "0.8.1",
@@ -29636,6 +28836,806 @@
       "requires": {
         "@webassemblyjs/ast": "1.11.1",
         "@xtuc/long": "4.2.2"
+      }
+    },
+    "@webolucio/craco": {
+      "version": "file:packages/craco",
+      "requires": {
+        "@babel/types": "^7.19.3",
+        "@jest/types": "^29.1.2",
+        "@types/cross-spawn": "^6.0.2",
+        "@types/eslint": "^8.4.6",
+        "@types/jest": "^29.1.1",
+        "@types/lodash": "^4.14.186",
+        "@types/semver": "^7.3.12",
+        "@webolucio/craco-types": "^7.0.1",
+        "autoprefixer": "^10.4.12",
+        "cosmiconfig": "^7.0.1",
+        "cosmiconfig-typescript-loader": "^1.0.0",
+        "cross-spawn": "^7.0.3",
+        "eslint-webpack-plugin": "^3.2.0",
+        "jest": "^29.1.2",
+        "lodash": "^4.17.21",
+        "react-scripts": "5.*",
+        "semver": "^7.3.7",
+        "ts-jest": "^29.0.3",
+        "typescript": "^4.8.4",
+        "webpack": "^5.74.0",
+        "webpack-merge": "^5.8.0"
+      },
+      "dependencies": {
+        "@jest/console": {
+          "version": "29.1.2",
+          "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.1.2.tgz",
+          "integrity": "sha512-ujEBCcYs82BTmRxqfHMQggSlkUZP63AE5YEaTPj7eFyJOzukkTorstOUC7L6nE3w5SYadGVAnTsQ/ZjTGL0qYQ==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^29.1.2",
+            "@types/node": "*",
+            "chalk": "^4.0.0",
+            "jest-message-util": "^29.1.2",
+            "jest-util": "^29.1.2",
+            "slash": "^3.0.0"
+          }
+        },
+        "@jest/core": {
+          "version": "29.1.2",
+          "resolved": "https://registry.npmjs.org/@jest/core/-/core-29.1.2.tgz",
+          "integrity": "sha512-sCO2Va1gikvQU2ynDN8V4+6wB7iVrD2CvT0zaRst4rglf56yLly0NQ9nuRRAWFeimRf+tCdFsb1Vk1N9LrrMPA==",
+          "dev": true,
+          "requires": {
+            "@jest/console": "^29.1.2",
+            "@jest/reporters": "^29.1.2",
+            "@jest/test-result": "^29.1.2",
+            "@jest/transform": "^29.1.2",
+            "@jest/types": "^29.1.2",
+            "@types/node": "*",
+            "ansi-escapes": "^4.2.1",
+            "chalk": "^4.0.0",
+            "ci-info": "^3.2.0",
+            "exit": "^0.1.2",
+            "graceful-fs": "^4.2.9",
+            "jest-changed-files": "^29.0.0",
+            "jest-config": "^29.1.2",
+            "jest-haste-map": "^29.1.2",
+            "jest-message-util": "^29.1.2",
+            "jest-regex-util": "^29.0.0",
+            "jest-resolve": "^29.1.2",
+            "jest-resolve-dependencies": "^29.1.2",
+            "jest-runner": "^29.1.2",
+            "jest-runtime": "^29.1.2",
+            "jest-snapshot": "^29.1.2",
+            "jest-util": "^29.1.2",
+            "jest-validate": "^29.1.2",
+            "jest-watcher": "^29.1.2",
+            "micromatch": "^4.0.4",
+            "pretty-format": "^29.1.2",
+            "slash": "^3.0.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "@jest/environment": {
+          "version": "29.1.2",
+          "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.1.2.tgz",
+          "integrity": "sha512-rG7xZ2UeOfvOVzoLIJ0ZmvPl4tBEQ2n73CZJSlzUjPw4or1oSWC0s0Rk0ZX+pIBJ04aVr6hLWFn1DFtrnf8MhQ==",
+          "dev": true,
+          "requires": {
+            "@jest/fake-timers": "^29.1.2",
+            "@jest/types": "^29.1.2",
+            "@types/node": "*",
+            "jest-mock": "^29.1.2"
+          }
+        },
+        "@jest/expect": {
+          "version": "29.1.2",
+          "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.1.2.tgz",
+          "integrity": "sha512-FXw/UmaZsyfRyvZw3M6POgSNqwmuOXJuzdNiMWW9LCYo0GRoRDhg+R5iq5higmRTHQY7hx32+j7WHwinRmoILQ==",
+          "dev": true,
+          "requires": {
+            "expect": "^29.1.2",
+            "jest-snapshot": "^29.1.2"
+          }
+        },
+        "@jest/expect-utils": {
+          "version": "29.1.2",
+          "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.1.2.tgz",
+          "integrity": "sha512-4a48bhKfGj/KAH39u0ppzNTABXQ8QPccWAFUFobWBaEMSMp+sB31Z2fK/l47c4a/Mu1po2ffmfAIPxXbVTXdtg==",
+          "dev": true,
+          "requires": {
+            "jest-get-type": "^29.0.0"
+          }
+        },
+        "@jest/fake-timers": {
+          "version": "29.1.2",
+          "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.1.2.tgz",
+          "integrity": "sha512-GppaEqS+QQYegedxVMpCe2xCXxxeYwQ7RsNx55zc8f+1q1qevkZGKequfTASI7ejmg9WwI+SJCrHe9X11bLL9Q==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^29.1.2",
+            "@sinonjs/fake-timers": "^9.1.2",
+            "@types/node": "*",
+            "jest-message-util": "^29.1.2",
+            "jest-mock": "^29.1.2",
+            "jest-util": "^29.1.2"
+          }
+        },
+        "@jest/globals": {
+          "version": "29.1.2",
+          "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.1.2.tgz",
+          "integrity": "sha512-uMgfERpJYoQmykAd0ffyMq8wignN4SvLUG6orJQRe9WAlTRc9cdpCaE/29qurXixYJVZWUqIBXhSk8v5xN1V9g==",
+          "dev": true,
+          "requires": {
+            "@jest/environment": "^29.1.2",
+            "@jest/expect": "^29.1.2",
+            "@jest/types": "^29.1.2",
+            "jest-mock": "^29.1.2"
+          }
+        },
+        "@jest/reporters": {
+          "version": "29.1.2",
+          "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.1.2.tgz",
+          "integrity": "sha512-X4fiwwyxy9mnfpxL0g9DD0KcTmEIqP0jUdnc2cfa9riHy+I6Gwwp5vOZiwyg0vZxfSDxrOlK9S4+340W4d+DAA==",
+          "dev": true,
+          "requires": {
+            "@bcoe/v8-coverage": "^0.2.3",
+            "@jest/console": "^29.1.2",
+            "@jest/test-result": "^29.1.2",
+            "@jest/transform": "^29.1.2",
+            "@jest/types": "^29.1.2",
+            "@jridgewell/trace-mapping": "^0.3.15",
+            "@types/node": "*",
+            "chalk": "^4.0.0",
+            "collect-v8-coverage": "^1.0.0",
+            "exit": "^0.1.2",
+            "glob": "^7.1.3",
+            "graceful-fs": "^4.2.9",
+            "istanbul-lib-coverage": "^3.0.0",
+            "istanbul-lib-instrument": "^5.1.0",
+            "istanbul-lib-report": "^3.0.0",
+            "istanbul-lib-source-maps": "^4.0.0",
+            "istanbul-reports": "^3.1.3",
+            "jest-message-util": "^29.1.2",
+            "jest-util": "^29.1.2",
+            "jest-worker": "^29.1.2",
+            "slash": "^3.0.0",
+            "string-length": "^4.0.1",
+            "strip-ansi": "^6.0.0",
+            "terminal-link": "^2.0.0",
+            "v8-to-istanbul": "^9.0.1"
+          }
+        },
+        "@jest/schemas": {
+          "version": "29.0.0",
+          "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.0.0.tgz",
+          "integrity": "sha512-3Ab5HgYIIAnS0HjqJHQYZS+zXc4tUmTmBH3z83ajI6afXp8X3ZtdLX+nXx+I7LNkJD7uN9LAVhgnjDgZa2z0kA==",
+          "dev": true,
+          "requires": {
+            "@sinclair/typebox": "^0.24.1"
+          }
+        },
+        "@jest/source-map": {
+          "version": "29.0.0",
+          "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-29.0.0.tgz",
+          "integrity": "sha512-nOr+0EM8GiHf34mq2GcJyz/gYFyLQ2INDhAylrZJ9mMWoW21mLBfZa0BUVPPMxVYrLjeiRe2Z7kWXOGnS0TFhQ==",
+          "dev": true,
+          "requires": {
+            "@jridgewell/trace-mapping": "^0.3.15",
+            "callsites": "^3.0.0",
+            "graceful-fs": "^4.2.9"
+          }
+        },
+        "@jest/test-result": {
+          "version": "29.1.2",
+          "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.1.2.tgz",
+          "integrity": "sha512-jjYYjjumCJjH9hHCoMhA8PCl1OxNeGgAoZ7yuGYILRJX9NjgzTN0pCT5qAoYR4jfOP8htIByvAlz9vfNSSBoVg==",
+          "dev": true,
+          "requires": {
+            "@jest/console": "^29.1.2",
+            "@jest/types": "^29.1.2",
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "collect-v8-coverage": "^1.0.0"
+          }
+        },
+        "@jest/test-sequencer": {
+          "version": "29.1.2",
+          "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.1.2.tgz",
+          "integrity": "sha512-fU6dsUqqm8sA+cd85BmeF7Gu9DsXVWFdGn9taxM6xN1cKdcP/ivSgXh5QucFRFz1oZxKv3/9DYYbq0ULly3P/Q==",
+          "dev": true,
+          "requires": {
+            "@jest/test-result": "^29.1.2",
+            "graceful-fs": "^4.2.9",
+            "jest-haste-map": "^29.1.2",
+            "slash": "^3.0.0"
+          }
+        },
+        "@jest/transform": {
+          "version": "29.1.2",
+          "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.1.2.tgz",
+          "integrity": "sha512-2uaUuVHTitmkx1tHF+eBjb4p7UuzBG7SXIaA/hNIkaMP6K+gXYGxP38ZcrofzqN0HeZ7A90oqsOa97WU7WZkSw==",
+          "dev": true,
+          "requires": {
+            "@babel/core": "^7.11.6",
+            "@jest/types": "^29.1.2",
+            "@jridgewell/trace-mapping": "^0.3.15",
+            "babel-plugin-istanbul": "^6.1.1",
+            "chalk": "^4.0.0",
+            "convert-source-map": "^1.4.0",
+            "fast-json-stable-stringify": "^2.1.0",
+            "graceful-fs": "^4.2.9",
+            "jest-haste-map": "^29.1.2",
+            "jest-regex-util": "^29.0.0",
+            "jest-util": "^29.1.2",
+            "micromatch": "^4.0.4",
+            "pirates": "^4.0.4",
+            "slash": "^3.0.0",
+            "write-file-atomic": "^4.0.1"
+          }
+        },
+        "@jest/types": {
+          "version": "29.1.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.1.2.tgz",
+          "integrity": "sha512-DcXGtoTykQB5jiwCmVr8H4vdg2OJhQex3qPkG+ISyDO7xQXbt/4R6dowcRyPemRnkH7JoHvZuxPBdlq+9JxFCg==",
+          "dev": true,
+          "requires": {
+            "@jest/schemas": "^29.0.0",
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^17.0.8",
+            "chalk": "^4.0.0"
+          }
+        },
+        "ansi-styles": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+          "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+          "dev": true
+        },
+        "babel-jest": {
+          "version": "29.1.2",
+          "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.1.2.tgz",
+          "integrity": "sha512-IuG+F3HTHryJb7gacC7SQ59A9kO56BctUsT67uJHp1mMCHUOMXpDwOHWGifWqdWVknN2WNkCVQELPjXx0aLJ9Q==",
+          "dev": true,
+          "requires": {
+            "@jest/transform": "^29.1.2",
+            "@types/babel__core": "^7.1.14",
+            "babel-plugin-istanbul": "^6.1.1",
+            "babel-preset-jest": "^29.0.2",
+            "chalk": "^4.0.0",
+            "graceful-fs": "^4.2.9",
+            "slash": "^3.0.0"
+          }
+        },
+        "babel-plugin-jest-hoist": {
+          "version": "29.0.2",
+          "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.0.2.tgz",
+          "integrity": "sha512-eBr2ynAEFjcebVvu8Ktx580BD1QKCrBG1XwEUTXJe285p9HA/4hOhfWCFRQhTKSyBV0VzjhG7H91Eifz9s29hg==",
+          "dev": true,
+          "requires": {
+            "@babel/template": "^7.3.3",
+            "@babel/types": "^7.3.3",
+            "@types/babel__core": "^7.1.14",
+            "@types/babel__traverse": "^7.0.6"
+          }
+        },
+        "babel-preset-jest": {
+          "version": "29.0.2",
+          "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-29.0.2.tgz",
+          "integrity": "sha512-BeVXp7rH5TK96ofyEnHjznjLMQ2nAeDJ+QzxKnHAAMs0RgrQsCywjAN8m4mOm5Di0pxU//3AoEeJJrerMH5UeA==",
+          "dev": true,
+          "requires": {
+            "babel-plugin-jest-hoist": "^29.0.2",
+            "babel-preset-current-node-syntax": "^1.0.0"
+          }
+        },
+        "camelcase": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+          "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+          "dev": true
+        },
+        "cosmiconfig-typescript-loader": {
+          "version": "1.0.9",
+          "resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-1.0.9.tgz",
+          "integrity": "sha512-tRuMRhxN4m1Y8hP9SNYfz7jRwt8lZdWxdjg/ohg5esKmsndJIn4yT96oJVcf5x0eA11taXl+sIp+ielu529k6g==",
+          "requires": {
+            "cosmiconfig": "^7",
+            "ts-node": "^10.7.0"
+          }
+        },
+        "diff-sequences": {
+          "version": "29.0.0",
+          "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.0.0.tgz",
+          "integrity": "sha512-7Qe/zd1wxSDL4D/X/FPjOMB+ZMDt71W94KYaq05I2l0oQqgXgs7s4ftYYmV38gBSrPz2vcygxfs1xn0FT+rKNA==",
+          "dev": true
+        },
+        "expect": {
+          "version": "29.1.2",
+          "resolved": "https://registry.npmjs.org/expect/-/expect-29.1.2.tgz",
+          "integrity": "sha512-AuAGn1uxva5YBbBlXb+2JPxJRuemZsmlGcapPXWNSBNsQtAULfjioREGBWuI0EOvYUKjDnrCy8PW5Zlr1md5mw==",
+          "dev": true,
+          "requires": {
+            "@jest/expect-utils": "^29.1.2",
+            "jest-get-type": "^29.0.0",
+            "jest-matcher-utils": "^29.1.2",
+            "jest-message-util": "^29.1.2",
+            "jest-util": "^29.1.2"
+          }
+        },
+        "jest": {
+          "version": "29.1.2",
+          "resolved": "https://registry.npmjs.org/jest/-/jest-29.1.2.tgz",
+          "integrity": "sha512-5wEIPpCezgORnqf+rCaYD1SK+mNN7NsstWzIsuvsnrhR/hSxXWd82oI7DkrbJ+XTD28/eG8SmxdGvukrGGK6Tw==",
+          "dev": true,
+          "requires": {
+            "@jest/core": "^29.1.2",
+            "@jest/types": "^29.1.2",
+            "import-local": "^3.0.2",
+            "jest-cli": "^29.1.2"
+          }
+        },
+        "jest-changed-files": {
+          "version": "29.0.0",
+          "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-29.0.0.tgz",
+          "integrity": "sha512-28/iDMDrUpGoCitTURuDqUzWQoWmOmOKOFST1mi2lwh62X4BFf6khgH3uSuo1e49X/UDjuApAj3w0wLOex4VPQ==",
+          "dev": true,
+          "requires": {
+            "execa": "^5.0.0",
+            "p-limit": "^3.1.0"
+          }
+        },
+        "jest-circus": {
+          "version": "29.1.2",
+          "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.1.2.tgz",
+          "integrity": "sha512-ajQOdxY6mT9GtnfJRZBRYS7toNIJayiiyjDyoZcnvPRUPwJ58JX0ci0PKAKUo2C1RyzlHw0jabjLGKksO42JGA==",
+          "dev": true,
+          "requires": {
+            "@jest/environment": "^29.1.2",
+            "@jest/expect": "^29.1.2",
+            "@jest/test-result": "^29.1.2",
+            "@jest/types": "^29.1.2",
+            "@types/node": "*",
+            "chalk": "^4.0.0",
+            "co": "^4.6.0",
+            "dedent": "^0.7.0",
+            "is-generator-fn": "^2.0.0",
+            "jest-each": "^29.1.2",
+            "jest-matcher-utils": "^29.1.2",
+            "jest-message-util": "^29.1.2",
+            "jest-runtime": "^29.1.2",
+            "jest-snapshot": "^29.1.2",
+            "jest-util": "^29.1.2",
+            "p-limit": "^3.1.0",
+            "pretty-format": "^29.1.2",
+            "slash": "^3.0.0",
+            "stack-utils": "^2.0.3"
+          }
+        },
+        "jest-cli": {
+          "version": "29.1.2",
+          "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-29.1.2.tgz",
+          "integrity": "sha512-vsvBfQ7oS2o4MJdAH+4u9z76Vw5Q8WBQF5MchDbkylNknZdrPTX1Ix7YRJyTlOWqRaS7ue/cEAn+E4V1MWyMzw==",
+          "dev": true,
+          "requires": {
+            "@jest/core": "^29.1.2",
+            "@jest/test-result": "^29.1.2",
+            "@jest/types": "^29.1.2",
+            "chalk": "^4.0.0",
+            "exit": "^0.1.2",
+            "graceful-fs": "^4.2.9",
+            "import-local": "^3.0.2",
+            "jest-config": "^29.1.2",
+            "jest-util": "^29.1.2",
+            "jest-validate": "^29.1.2",
+            "prompts": "^2.0.1",
+            "yargs": "^17.3.1"
+          }
+        },
+        "jest-config": {
+          "version": "29.1.2",
+          "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.1.2.tgz",
+          "integrity": "sha512-EC3Zi86HJUOz+2YWQcJYQXlf0zuBhJoeyxLM6vb6qJsVmpP7KcCP1JnyF0iaqTaXdBP8Rlwsvs7hnKWQWWLwwA==",
+          "dev": true,
+          "requires": {
+            "@babel/core": "^7.11.6",
+            "@jest/test-sequencer": "^29.1.2",
+            "@jest/types": "^29.1.2",
+            "babel-jest": "^29.1.2",
+            "chalk": "^4.0.0",
+            "ci-info": "^3.2.0",
+            "deepmerge": "^4.2.2",
+            "glob": "^7.1.3",
+            "graceful-fs": "^4.2.9",
+            "jest-circus": "^29.1.2",
+            "jest-environment-node": "^29.1.2",
+            "jest-get-type": "^29.0.0",
+            "jest-regex-util": "^29.0.0",
+            "jest-resolve": "^29.1.2",
+            "jest-runner": "^29.1.2",
+            "jest-util": "^29.1.2",
+            "jest-validate": "^29.1.2",
+            "micromatch": "^4.0.4",
+            "parse-json": "^5.2.0",
+            "pretty-format": "^29.1.2",
+            "slash": "^3.0.0",
+            "strip-json-comments": "^3.1.1"
+          }
+        },
+        "jest-diff": {
+          "version": "29.1.2",
+          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.1.2.tgz",
+          "integrity": "sha512-4GQts0aUopVvecIT4IwD/7xsBaMhKTYoM4/njE/aVw9wpw+pIUVp8Vab/KnSzSilr84GnLBkaP3JLDnQYCKqVQ==",
+          "dev": true,
+          "requires": {
+            "chalk": "^4.0.0",
+            "diff-sequences": "^29.0.0",
+            "jest-get-type": "^29.0.0",
+            "pretty-format": "^29.1.2"
+          }
+        },
+        "jest-docblock": {
+          "version": "29.0.0",
+          "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.0.0.tgz",
+          "integrity": "sha512-s5Kpra/kLzbqu9dEjov30kj1n4tfu3e7Pl8v+f8jOkeWNqM6Ds8jRaJfZow3ducoQUrf2Z4rs2N5S3zXnb83gw==",
+          "dev": true,
+          "requires": {
+            "detect-newline": "^3.0.0"
+          }
+        },
+        "jest-each": {
+          "version": "29.1.2",
+          "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-29.1.2.tgz",
+          "integrity": "sha512-AmTQp9b2etNeEwMyr4jc0Ql/LIX/dhbgP21gHAizya2X6rUspHn2gysMXaj6iwWuOJ2sYRgP8c1P4cXswgvS1A==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^29.1.2",
+            "chalk": "^4.0.0",
+            "jest-get-type": "^29.0.0",
+            "jest-util": "^29.1.2",
+            "pretty-format": "^29.1.2"
+          }
+        },
+        "jest-environment-node": {
+          "version": "29.1.2",
+          "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.1.2.tgz",
+          "integrity": "sha512-C59yVbdpY8682u6k/lh8SUMDJPbOyCHOTgLVVi1USWFxtNV+J8fyIwzkg+RJIVI30EKhKiAGNxYaFr3z6eyNhQ==",
+          "dev": true,
+          "requires": {
+            "@jest/environment": "^29.1.2",
+            "@jest/fake-timers": "^29.1.2",
+            "@jest/types": "^29.1.2",
+            "@types/node": "*",
+            "jest-mock": "^29.1.2",
+            "jest-util": "^29.1.2"
+          }
+        },
+        "jest-get-type": {
+          "version": "29.0.0",
+          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.0.0.tgz",
+          "integrity": "sha512-83X19z/HuLKYXYHskZlBAShO7UfLFXu/vWajw9ZNJASN32li8yHMaVGAQqxFW1RCFOkB7cubaL6FaJVQqqJLSw==",
+          "dev": true
+        },
+        "jest-haste-map": {
+          "version": "29.1.2",
+          "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.1.2.tgz",
+          "integrity": "sha512-xSjbY8/BF11Jh3hGSPfYTa/qBFrm3TPM7WU8pU93m2gqzORVLkHFWvuZmFsTEBPRKndfewXhMOuzJNHyJIZGsw==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^29.1.2",
+            "@types/graceful-fs": "^4.1.3",
+            "@types/node": "*",
+            "anymatch": "^3.0.3",
+            "fb-watchman": "^2.0.0",
+            "fsevents": "^2.3.2",
+            "graceful-fs": "^4.2.9",
+            "jest-regex-util": "^29.0.0",
+            "jest-util": "^29.1.2",
+            "jest-worker": "^29.1.2",
+            "micromatch": "^4.0.4",
+            "walker": "^1.0.8"
+          }
+        },
+        "jest-leak-detector": {
+          "version": "29.1.2",
+          "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.1.2.tgz",
+          "integrity": "sha512-TG5gAZJpgmZtjb6oWxBLf2N6CfQ73iwCe6cofu/Uqv9iiAm6g502CAnGtxQaTfpHECBdVEMRBhomSXeLnoKjiQ==",
+          "dev": true,
+          "requires": {
+            "jest-get-type": "^29.0.0",
+            "pretty-format": "^29.1.2"
+          }
+        },
+        "jest-matcher-utils": {
+          "version": "29.1.2",
+          "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.1.2.tgz",
+          "integrity": "sha512-MV5XrD3qYSW2zZSHRRceFzqJ39B2z11Qv0KPyZYxnzDHFeYZGJlgGi0SW+IXSJfOewgJp/Km/7lpcFT+cgZypw==",
+          "dev": true,
+          "requires": {
+            "chalk": "^4.0.0",
+            "jest-diff": "^29.1.2",
+            "jest-get-type": "^29.0.0",
+            "pretty-format": "^29.1.2"
+          }
+        },
+        "jest-message-util": {
+          "version": "29.1.2",
+          "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.1.2.tgz",
+          "integrity": "sha512-9oJ2Os+Qh6IlxLpmvshVbGUiSkZVc2FK+uGOm6tghafnB2RyjKAxMZhtxThRMxfX1J1SOMhTn9oK3/MutRWQJQ==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.12.13",
+            "@jest/types": "^29.1.2",
+            "@types/stack-utils": "^2.0.0",
+            "chalk": "^4.0.0",
+            "graceful-fs": "^4.2.9",
+            "micromatch": "^4.0.4",
+            "pretty-format": "^29.1.2",
+            "slash": "^3.0.0",
+            "stack-utils": "^2.0.3"
+          }
+        },
+        "jest-mock": {
+          "version": "29.1.2",
+          "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.1.2.tgz",
+          "integrity": "sha512-PFDAdjjWbjPUtQPkQufvniXIS3N9Tv7tbibePEjIIprzjgo0qQlyUiVMrT4vL8FaSJo1QXifQUOuPH3HQC/aMA==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^29.1.2",
+            "@types/node": "*",
+            "jest-util": "^29.1.2"
+          }
+        },
+        "jest-regex-util": {
+          "version": "29.0.0",
+          "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.0.0.tgz",
+          "integrity": "sha512-BV7VW7Sy0fInHWN93MMPtlClweYv2qrSCwfeFWmpribGZtQPWNvRSq9XOVgOEjU1iBGRKXUZil0o2AH7Iy9Lug==",
+          "dev": true
+        },
+        "jest-resolve": {
+          "version": "29.1.2",
+          "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.1.2.tgz",
+          "integrity": "sha512-7fcOr+k7UYSVRJYhSmJHIid3AnDBcLQX3VmT9OSbPWsWz1MfT7bcoerMhADKGvKCoMpOHUQaDHtQoNp/P9JMGg==",
+          "dev": true,
+          "requires": {
+            "chalk": "^4.0.0",
+            "graceful-fs": "^4.2.9",
+            "jest-haste-map": "^29.1.2",
+            "jest-pnp-resolver": "^1.2.2",
+            "jest-util": "^29.1.2",
+            "jest-validate": "^29.1.2",
+            "resolve": "^1.20.0",
+            "resolve.exports": "^1.1.0",
+            "slash": "^3.0.0"
+          }
+        },
+        "jest-resolve-dependencies": {
+          "version": "29.1.2",
+          "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-29.1.2.tgz",
+          "integrity": "sha512-44yYi+yHqNmH3OoWZvPgmeeiwKxhKV/0CfrzaKLSkZG9gT973PX8i+m8j6pDrTYhhHoiKfF3YUFg/6AeuHw4HQ==",
+          "dev": true,
+          "requires": {
+            "jest-regex-util": "^29.0.0",
+            "jest-snapshot": "^29.1.2"
+          }
+        },
+        "jest-runner": {
+          "version": "29.1.2",
+          "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.1.2.tgz",
+          "integrity": "sha512-yy3LEWw8KuBCmg7sCGDIqKwJlULBuNIQa2eFSVgVASWdXbMYZ9H/X0tnXt70XFoGf92W2sOQDOIFAA6f2BG04Q==",
+          "dev": true,
+          "requires": {
+            "@jest/console": "^29.1.2",
+            "@jest/environment": "^29.1.2",
+            "@jest/test-result": "^29.1.2",
+            "@jest/transform": "^29.1.2",
+            "@jest/types": "^29.1.2",
+            "@types/node": "*",
+            "chalk": "^4.0.0",
+            "emittery": "^0.10.2",
+            "graceful-fs": "^4.2.9",
+            "jest-docblock": "^29.0.0",
+            "jest-environment-node": "^29.1.2",
+            "jest-haste-map": "^29.1.2",
+            "jest-leak-detector": "^29.1.2",
+            "jest-message-util": "^29.1.2",
+            "jest-resolve": "^29.1.2",
+            "jest-runtime": "^29.1.2",
+            "jest-util": "^29.1.2",
+            "jest-watcher": "^29.1.2",
+            "jest-worker": "^29.1.2",
+            "p-limit": "^3.1.0",
+            "source-map-support": "0.5.13"
+          }
+        },
+        "jest-runtime": {
+          "version": "29.1.2",
+          "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.1.2.tgz",
+          "integrity": "sha512-jr8VJLIf+cYc+8hbrpt412n5jX3tiXmpPSYTGnwcvNemY+EOuLNiYnHJ3Kp25rkaAcTWOEI4ZdOIQcwYcXIAZw==",
+          "dev": true,
+          "requires": {
+            "@jest/environment": "^29.1.2",
+            "@jest/fake-timers": "^29.1.2",
+            "@jest/globals": "^29.1.2",
+            "@jest/source-map": "^29.0.0",
+            "@jest/test-result": "^29.1.2",
+            "@jest/transform": "^29.1.2",
+            "@jest/types": "^29.1.2",
+            "@types/node": "*",
+            "chalk": "^4.0.0",
+            "cjs-module-lexer": "^1.0.0",
+            "collect-v8-coverage": "^1.0.0",
+            "glob": "^7.1.3",
+            "graceful-fs": "^4.2.9",
+            "jest-haste-map": "^29.1.2",
+            "jest-message-util": "^29.1.2",
+            "jest-mock": "^29.1.2",
+            "jest-regex-util": "^29.0.0",
+            "jest-resolve": "^29.1.2",
+            "jest-snapshot": "^29.1.2",
+            "jest-util": "^29.1.2",
+            "slash": "^3.0.0",
+            "strip-bom": "^4.0.0"
+          }
+        },
+        "jest-snapshot": {
+          "version": "29.1.2",
+          "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.1.2.tgz",
+          "integrity": "sha512-rYFomGpVMdBlfwTYxkUp3sjD6usptvZcONFYNqVlaz4EpHPnDvlWjvmOQ9OCSNKqYZqLM2aS3wq01tWujLg7gg==",
+          "dev": true,
+          "requires": {
+            "@babel/core": "^7.11.6",
+            "@babel/generator": "^7.7.2",
+            "@babel/plugin-syntax-jsx": "^7.7.2",
+            "@babel/plugin-syntax-typescript": "^7.7.2",
+            "@babel/traverse": "^7.7.2",
+            "@babel/types": "^7.3.3",
+            "@jest/expect-utils": "^29.1.2",
+            "@jest/transform": "^29.1.2",
+            "@jest/types": "^29.1.2",
+            "@types/babel__traverse": "^7.0.6",
+            "@types/prettier": "^2.1.5",
+            "babel-preset-current-node-syntax": "^1.0.0",
+            "chalk": "^4.0.0",
+            "expect": "^29.1.2",
+            "graceful-fs": "^4.2.9",
+            "jest-diff": "^29.1.2",
+            "jest-get-type": "^29.0.0",
+            "jest-haste-map": "^29.1.2",
+            "jest-matcher-utils": "^29.1.2",
+            "jest-message-util": "^29.1.2",
+            "jest-util": "^29.1.2",
+            "natural-compare": "^1.4.0",
+            "pretty-format": "^29.1.2",
+            "semver": "^7.3.5"
+          }
+        },
+        "jest-util": {
+          "version": "29.1.2",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.1.2.tgz",
+          "integrity": "sha512-vPCk9F353i0Ymx3WQq3+a4lZ07NXu9Ca8wya6o4Fe4/aO1e1awMMprZ3woPFpKwghEOW+UXgd15vVotuNN9ONQ==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^29.1.2",
+            "@types/node": "*",
+            "chalk": "^4.0.0",
+            "ci-info": "^3.2.0",
+            "graceful-fs": "^4.2.9",
+            "picomatch": "^2.2.3"
+          }
+        },
+        "jest-validate": {
+          "version": "29.1.2",
+          "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.1.2.tgz",
+          "integrity": "sha512-k71pOslNlV8fVyI+mEySy2pq9KdXdgZtm7NHrBX8LghJayc3wWZH0Yr0mtYNGaCU4F1OLPXRkwZR0dBm/ClshA==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^29.1.2",
+            "camelcase": "^6.2.0",
+            "chalk": "^4.0.0",
+            "jest-get-type": "^29.0.0",
+            "leven": "^3.1.0",
+            "pretty-format": "^29.1.2"
+          }
+        },
+        "jest-watcher": {
+          "version": "29.1.2",
+          "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.1.2.tgz",
+          "integrity": "sha512-6JUIUKVdAvcxC6bM8/dMgqY2N4lbT+jZVsxh0hCJRbwkIEnbr/aPjMQ28fNDI5lB51Klh00MWZZeVf27KBUj5w==",
+          "dev": true,
+          "requires": {
+            "@jest/test-result": "^29.1.2",
+            "@jest/types": "^29.1.2",
+            "@types/node": "*",
+            "ansi-escapes": "^4.2.1",
+            "chalk": "^4.0.0",
+            "emittery": "^0.10.2",
+            "jest-util": "^29.1.2",
+            "string-length": "^4.0.1"
+          }
+        },
+        "jest-worker": {
+          "version": "29.1.2",
+          "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.1.2.tgz",
+          "integrity": "sha512-AdTZJxKjTSPHbXT/AIOjQVmoFx0LHFcVabWu0sxI7PAy7rFf8c0upyvgBKgguVXdM4vY74JdwkyD4hSmpTW8jA==",
+          "dev": true,
+          "requires": {
+            "@types/node": "*",
+            "jest-util": "^29.1.2",
+            "merge-stream": "^2.0.0",
+            "supports-color": "^8.0.0"
+          }
+        },
+        "pretty-format": {
+          "version": "29.1.2",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.1.2.tgz",
+          "integrity": "sha512-CGJ6VVGXVRP2o2Dorl4mAwwvDWT25luIsYhkyVQW32E4nL+TgW939J7LlKT/npq5Cpq6j3s+sy+13yk7xYpBmg==",
+          "dev": true,
+          "requires": {
+            "@jest/schemas": "^29.0.0",
+            "ansi-styles": "^5.0.0",
+            "react-is": "^18.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "8.1.1",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+          "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "ts-jest": {
+          "version": "29.0.3",
+          "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.0.3.tgz",
+          "integrity": "sha512-Ibygvmuyq1qp/z3yTh9QTwVVAbFdDy/+4BtIQR2sp6baF2SJU/8CKK/hhnGIDY2L90Az2jIqTwZPnN2p+BweiQ==",
+          "dev": true,
+          "requires": {
+            "bs-logger": "0.x",
+            "fast-json-stable-stringify": "2.x",
+            "jest-util": "^29.0.0",
+            "json5": "^2.2.1",
+            "lodash.memoize": "4.x",
+            "make-error": "1.x",
+            "semver": "7.x",
+            "yargs-parser": "^21.0.1"
+          }
+        }
+      }
+    },
+    "@webolucio/craco-types": {
+      "version": "file:packages/craco-types",
+      "requires": {
+        "@babel/types": "^7.19.3",
+        "@jest/types": "^29.1.2",
+        "@types/eslint": "^8.4.6",
+        "autoprefixer": "^10.4.12",
+        "eslint-webpack-plugin": "^3.2.0",
+        "typescript": "^4.8.4",
+        "webpack": "^5.74.0"
+      },
+      "dependencies": {
+        "@jest/schemas": {
+          "version": "29.0.0",
+          "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.0.0.tgz",
+          "integrity": "sha512-3Ab5HgYIIAnS0HjqJHQYZS+zXc4tUmTmBH3z83ajI6afXp8X3ZtdLX+nXx+I7LNkJD7uN9LAVhgnjDgZa2z0kA==",
+          "requires": {
+            "@sinclair/typebox": "^0.24.1"
+          }
+        },
+        "@jest/types": {
+          "version": "29.1.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.1.2.tgz",
+          "integrity": "sha512-DcXGtoTykQB5jiwCmVr8H4vdg2OJhQex3qPkG+ISyDO7xQXbt/4R6dowcRyPemRnkH7JoHvZuxPBdlq+9JxFCg==",
+          "requires": {
+            "@jest/schemas": "^29.0.0",
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^17.0.8",
+            "chalk": "^4.0.0"
+          }
+        }
       }
     },
     "@xtuc/ieee754": {

--- a/packages/craco-types/package.json
+++ b/packages/craco-types/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@craco/types",
+  "name": "@webolucio/craco-types",
   "description": "Official type declarations for @craco/craco",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/packages/craco-types/src/config.ts
+++ b/packages/craco-types/src/config.ts
@@ -9,6 +9,7 @@ import type {
 import type { Configuration as DevServerConfig } from 'webpack-dev-server';
 import type {
   BaseContext,
+  CraPaths,
   DevServerContext,
   JestContext,
   WebpackContext,
@@ -101,4 +102,5 @@ export interface CracoConfig {
   webpack?: CracoWebpackConfig;
   devServer?: CracoDevServerConfig;
   plugins?: CracoPluginDefinition<any>[];
+  paths?: Configure<CraPaths | undefined, BaseContext>;
 }

--- a/packages/craco/package.json
+++ b/packages/craco/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@craco/craco",
+  "name": "@webolucio/craco",
   "description": "Create React App Configuration Override, an easy and comprehensible configuration layer for create-react-app.",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
@@ -44,13 +44,13 @@
   },
   "devDependencies": {
     "@babel/types": "^7.19.3",
-    "@craco/types": "*",
     "@jest/types": "^29.1.2",
     "@types/cross-spawn": "^6.0.2",
     "@types/eslint": "^8.4.6",
     "@types/jest": "^29.1.1",
     "@types/lodash": "^4.14.186",
     "@types/semver": "^7.3.12",
+    "@webolucio/craco-types": "^7.0.1",
     "eslint-webpack-plugin": "^3.2.0",
     "jest": "^29.1.2",
     "react-scripts": "5.*",

--- a/packages/craco/src/lib/cra.ts
+++ b/packages/craco/src/lib/cra.ts
@@ -1,5 +1,6 @@
 import type {
   CracoConfig,
+  CraPaths,
   DevServerConfigProvider,
   JestConfigProvider,
 } from '@craco/types';
@@ -62,7 +63,7 @@ function overrideModule(modulePath: string, newModule: any) {
     throw new Error(`Module not found: ${modulePath}`);
   }
   require.cache[modulePath]!.exports = newModule;
-  log(`Overrided require cache for module: ${modulePath}`);
+  log(`Overrode require cache for module: ${modulePath}`);
 }
 
 function resolvePackageJson(cracoConfig: CracoConfig) {
@@ -89,12 +90,25 @@ export function getReactScriptVersion(cracoConfig: CracoConfig) {
 
 let _resolvedCraPaths: any = null;
 
+export function getCraPathsPath(cracoConfig: CracoConfig) {
+  return resolveConfigFilePath(cracoConfig, 'paths.js');
+}
+
 export function getCraPaths(cracoConfig: CracoConfig) {
   if (!_resolvedCraPaths) {
-    _resolvedCraPaths = require(resolveConfigFilePath(cracoConfig, 'paths.js'));
+    _resolvedCraPaths = require(getCraPathsPath(cracoConfig));
   }
 
   return _resolvedCraPaths;
+}
+
+export function overrideCraPaths(
+  cracoConfig: CracoConfig,
+  newConfig?: CraPaths
+) {
+  overrideModule(getCraPathsPath(cracoConfig), newConfig);
+
+  log('Overrode CRA paths config.');
 }
 
 /************  Webpack Dev Config  ************/
@@ -137,7 +151,7 @@ export function overrideWebpackDevConfig(
     overrideModule(result.filepath, () => newConfig);
   }
 
-  log('Overrided Webpack dev config.');
+  log('Overrode Webpack dev config.');
 }
 
 /************  Webpack Prod Config  ************/
@@ -180,7 +194,7 @@ export function overrideWebpackProdConfig(
     overrideModule(result.filepath, () => newConfig);
   }
 
-  log('Overrided Webpack prod config.');
+  log('Overrode Webpack prod config.');
 }
 
 /************  Dev Server Config  ************/
@@ -211,7 +225,7 @@ export function overrideDevServerConfigProvider(
 
   overrideModule(filepath, configProvider);
 
-  log('Overrided dev server config provider.');
+  log('Overrode dev server config provider.');
 }
 
 export function loadDevServerUtils() {
@@ -227,7 +241,7 @@ export function overrideDevServerUtils(newUtils: any) {
 
   overrideModule(filepath, newUtils);
 
-  log('Overrided dev server utils.');
+  log('Overrode dev server utils.');
 }
 
 /************  Jest Config  ************/
@@ -256,7 +270,7 @@ export function overrideJestConfigProvider(
 
   overrideModule(filepath, configProvider);
 
-  log('Overrided Jest config provider.');
+  log('Overrode Jest config provider.');
 }
 
 /************  Scripts  *******************/

--- a/packages/craco/src/lib/features/paths/override.ts
+++ b/packages/craco/src/lib/features/paths/override.ts
@@ -1,0 +1,22 @@
+import type { BaseContext, CracoConfig, CraPaths } from '@craco/types';
+
+import { overrideCraPaths } from '../../cra';
+import { isFunction } from '../../utils';
+
+export function overridePaths(cracoConfig: CracoConfig, context: BaseContext) {
+  let newConfig: CraPaths | undefined = context.paths;
+  if (cracoConfig.paths) {
+    if (isFunction(cracoConfig.paths)) {
+      newConfig = cracoConfig.paths(newConfig, context);
+    } else {
+      newConfig = {
+        ...newConfig,
+        ...cracoConfig.paths,
+      };
+    }
+
+    overrideCraPaths(cracoConfig, newConfig);
+  }
+
+  return newConfig;
+}

--- a/packages/craco/src/scripts/build.ts
+++ b/packages/craco/src/scripts/build.ts
@@ -9,6 +9,7 @@ findArgsFromCli();
 
 import { loadCracoConfigAsync } from '../lib/config';
 import { build, getCraPaths } from '../lib/cra';
+import { overridePaths } from '../lib/features/paths/override';
 import { overrideWebpackProd } from '../lib/features/webpack/override';
 import { log } from '../lib/logger';
 import { validateCraVersion } from '../lib/validate-cra-version';
@@ -24,6 +25,7 @@ loadCracoConfigAsync(context).then((cracoConfig) => {
   validateCraVersion(cracoConfig);
 
   context.paths = getCraPaths(cracoConfig);
+  context.paths = overridePaths(cracoConfig, context);
 
   overrideWebpackProd(cracoConfig, context);
   build(cracoConfig);

--- a/packages/craco/src/scripts/start.ts
+++ b/packages/craco/src/scripts/start.ts
@@ -26,8 +26,8 @@ loadCracoConfigAsync(context).then((cracoConfig: CracoConfig) => {
   validateCraVersion(cracoConfig);
 
   context.paths = getCraPaths(cracoConfig);
-
   context.paths = overridePaths(cracoConfig, context);
+
   overrideWebpackDev(cracoConfig, context);
   overrideDevServer(cracoConfig, context);
 

--- a/packages/craco/src/scripts/start.ts
+++ b/packages/craco/src/scripts/start.ts
@@ -11,6 +11,7 @@ import { loadCracoConfigAsync } from '../lib/config';
 import { getCraPaths, start } from '../lib/cra';
 import { overrideDevServer } from '../lib/features/dev-server/override';
 import { overrideWebpackDev } from '../lib/features/webpack/override';
+import { overridePaths } from '../lib/features/paths/override';
 import { log } from '../lib/logger';
 import { validateCraVersion } from '../lib/validate-cra-version';
 
@@ -26,6 +27,7 @@ loadCracoConfigAsync(context).then((cracoConfig: CracoConfig) => {
 
   context.paths = getCraPaths(cracoConfig);
 
+  context.paths = overridePaths(cracoConfig, context);
   overrideWebpackDev(cracoConfig, context);
   overrideDevServer(cracoConfig, context);
 

--- a/packages/craco/src/scripts/test.ts
+++ b/packages/craco/src/scripts/test.ts
@@ -10,6 +10,7 @@ findArgsFromCli();
 import { loadCracoConfigAsync } from '../lib/config';
 import { getCraPaths, test } from '../lib/cra';
 import { overrideJest } from '../lib/features/jest/override';
+import { overridePaths } from '../lib/features/paths/override';
 import { log } from '../lib/logger';
 import { validateCraVersion } from '../lib/validate-cra-version';
 
@@ -24,6 +25,7 @@ loadCracoConfigAsync(context).then((cracoConfig: CracoConfig) => {
   validateCraVersion(cracoConfig);
 
   context.paths = getCraPaths(cracoConfig);
+  context.paths = overridePaths(cracoConfig, context);
 
   overrideJest(cracoConfig, context);
   test(cracoConfig);


### PR DESCRIPTION
We needed a way to override CRAs appHtml paths and some others in our monorepo, so I've created a way to override any of the default CRA path strings. I saw that this is already requested in several issues (#104 seems to be the main one, still open ones are  #414 and maybe #481) and even a PR was made that was closed eventually.

The method of overriding the path config follows the same logic as the other features of the package, you can either pass an object containing the definitions or specify a function that returns them.

After the new path values are set, the context paths also get overridden, for the sake of consistency.