### PR TITLE
feat: Override CRA paths

### DIFF
--- a/packages/craco-types/src/config.ts
+++ b/packages/craco-types/src/config.ts
@@ -9,6 +9,7 @@ import type {
 import type { Configuration as DevServerConfig } from 'webpack-dev-server';
 import type {
   BaseContext,
+  CraPaths,
   DevServerContext,
   JestContext,
   WebpackContext,
@@ -101,4 +102,5 @@ export interface CracoConfig {
   webpack?: CracoWebpackConfig;
   devServer?: CracoDevServerConfig;
   plugins?: CracoPluginDefinition<any>[];
+  paths?: Configure<CraPaths | undefined, BaseContext>;
 }

--- a/packages/craco/src/lib/cra.ts
+++ b/packages/craco/src/lib/cra.ts
@@ -1,5 +1,6 @@
 import type {
   CracoConfig,
+  CraPaths,
   DevServerConfigProvider,
   JestConfigProvider,
 } from '@craco/types';
@@ -62,7 +63,7 @@ function overrideModule(modulePath: string, newModule: any) {
     throw new Error(`Module not found: ${modulePath}`);
   }
   require.cache[modulePath]!.exports = newModule;
-  log(`Overrided require cache for module: ${modulePath}`);
+  log(`Overrode require cache for module: ${modulePath}`);
 }
 
 function resolvePackageJson(cracoConfig: CracoConfig) {
@@ -89,12 +90,25 @@ export function getReactScriptVersion(cracoConfig: CracoConfig) {
 
 let _resolvedCraPaths: any = null;
 
+export function getCraPathsPath(cracoConfig: CracoConfig) {
+  return resolveConfigFilePath(cracoConfig, 'paths.js');
+}
+
 export function getCraPaths(cracoConfig: CracoConfig) {
   if (!_resolvedCraPaths) {
-    _resolvedCraPaths = require(resolveConfigFilePath(cracoConfig, 'paths.js'));
+    _resolvedCraPaths = require(getCraPathsPath(cracoConfig));
   }
 
   return _resolvedCraPaths;
+}
+
+export function overrideCraPaths(
+  cracoConfig: CracoConfig,
+  newConfig?: CraPaths
+) {
+  overrideModule(getCraPathsPath(cracoConfig), newConfig);
+
+  log('Overrode CRA paths config.');
 }
 
 /************  Webpack Dev Config  ************/
@@ -137,7 +151,7 @@ export function overrideWebpackDevConfig(
     overrideModule(result.filepath, () => newConfig);
   }
 
-  log('Overrided Webpack dev config.');
+  log('Overrode Webpack dev config.');
 }
 
 /************  Webpack Prod Config  ************/
@@ -180,7 +194,7 @@ export function overrideWebpackProdConfig(
     overrideModule(result.filepath, () => newConfig);
   }
 
-  log('Overrided Webpack prod config.');
+  log('Overrode Webpack prod config.');
 }
 
 /************  Dev Server Config  ************/
@@ -211,7 +225,7 @@ export function overrideDevServerConfigProvider(
 
   overrideModule(filepath, configProvider);
 
-  log('Overrided dev server config provider.');
+  log('Overrode dev server config provider.');
 }
 
 export function loadDevServerUtils() {
@@ -227,7 +241,7 @@ export function overrideDevServerUtils(newUtils: any) {
 
   overrideModule(filepath, newUtils);
 
-  log('Overrided dev server utils.');
+  log('Overrode dev server utils.');
 }
 
 /************  Jest Config  ************/
@@ -256,7 +270,7 @@ export function overrideJestConfigProvider(
 
   overrideModule(filepath, configProvider);
 
-  log('Overrided Jest config provider.');
+  log('Overrode Jest config provider.');
 }
 
 /************  Scripts  *******************/

--- a/packages/craco/src/lib/features/paths/override.ts
+++ b/packages/craco/src/lib/features/paths/override.ts
@@ -1,0 +1,22 @@
+import type { BaseContext, CracoConfig, CraPaths } from '@craco/types';
+
+import { overrideCraPaths } from '../../cra';
+import { isFunction } from '../../utils';
+
+export function overridePaths(cracoConfig: CracoConfig, context: BaseContext) {
+  let newConfig: CraPaths | undefined = context.paths;
+  if (cracoConfig.paths) {
+    if (isFunction(cracoConfig.paths)) {
+      newConfig = cracoConfig.paths(newConfig, context);
+    } else {
+      newConfig = {
+        ...newConfig,
+        ...cracoConfig.paths,
+      };
+    }
+
+    overrideCraPaths(cracoConfig, newConfig);
+  }
+
+  return newConfig;
+}

--- a/packages/craco/src/scripts/build.ts
+++ b/packages/craco/src/scripts/build.ts
@@ -9,6 +9,7 @@ findArgsFromCli();
 
 import { loadCracoConfigAsync } from '../lib/config';
 import { build, getCraPaths } from '../lib/cra';
+import { overridePaths } from '../lib/features/paths/override';
 import { overrideWebpackProd } from '../lib/features/webpack/override';
 import { log } from '../lib/logger';
 import { validateCraVersion } from '../lib/validate-cra-version';
@@ -24,6 +25,7 @@ loadCracoConfigAsync(context).then((cracoConfig) => {
   validateCraVersion(cracoConfig);
 
   context.paths = getCraPaths(cracoConfig);
+  context.paths = overridePaths(cracoConfig, context);
 
   overrideWebpackProd(cracoConfig, context);
   build(cracoConfig);

--- a/packages/craco/src/scripts/start.ts
+++ b/packages/craco/src/scripts/start.ts
@@ -11,6 +11,7 @@ import { loadCracoConfigAsync } from '../lib/config';
 import { getCraPaths, start } from '../lib/cra';
 import { overrideDevServer } from '../lib/features/dev-server/override';
 import { overrideWebpackDev } from '../lib/features/webpack/override';
+import { overridePaths } from '../lib/features/paths/override';
 import { log } from '../lib/logger';
 import { validateCraVersion } from '../lib/validate-cra-version';
 
@@ -25,6 +26,7 @@ loadCracoConfigAsync(context).then((cracoConfig: CracoConfig) => {
   validateCraVersion(cracoConfig);
 
   context.paths = getCraPaths(cracoConfig);
+  context.paths = overridePaths(cracoConfig, context);
 
   overrideWebpackDev(cracoConfig, context);
   overrideDevServer(cracoConfig, context);

--- a/packages/craco/src/scripts/test.ts
+++ b/packages/craco/src/scripts/test.ts
@@ -10,6 +10,7 @@ findArgsFromCli();
 import { loadCracoConfigAsync } from '../lib/config';
 import { getCraPaths, test } from '../lib/cra';
 import { overrideJest } from '../lib/features/jest/override';
+import { overridePaths } from '../lib/features/paths/override';
 import { log } from '../lib/logger';
 import { validateCraVersion } from '../lib/validate-cra-version';
 
@@ -24,6 +25,7 @@ loadCracoConfigAsync(context).then((cracoConfig: CracoConfig) => {
   validateCraVersion(cracoConfig);
 
   context.paths = getCraPaths(cracoConfig);
+  context.paths = overridePaths(cracoConfig, context);
 
   overrideJest(cracoConfig, context);
   test(cracoConfig);


### PR DESCRIPTION
(Had to recreate it)
We needed a way to override CRAs appHtml paths and some others in our monorepo, so I've created a way to override any of the default CRA path strings. I saw that this is already requested in several issues (https://github.com/dilanx/craco/issues/104 seems to be the main one, still open ones are https://github.com/dilanx/craco/issues/414 and maybe https://github.com/dilanx/craco/issues/481) and even a PR was made that was closed eventually.

The method of overriding the path config follows the same logic as the other features of the package, you can either pass an object containing the definitions or specify a function that returns them.

After the new path values are set, the context paths also get overridden, for the sake of consistency.